### PR TITLE
Fix: https://github.com/jkingster/QuickTicket/issues/46

### DIFF
--- a/src/main/java/io/jacobking/quickticket/core/email/EmailConfig.java
+++ b/src/main/java/io/jacobking/quickticket/core/email/EmailConfig.java
@@ -74,17 +74,21 @@ public class EmailConfig {
 
         properties.setProperty(SMTP_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
         properties.setProperty(SMTP_TIMEOUT, DEFAULT_TIMEOUT);
+
         properties.setProperty("mail.debug", booleanAsString(email.getDebugging()));
         properties.setProperty("mail.smtp.ssl.protocols", "TLSv1.2");
 
         this.session = Session.getDefaultInstance(properties);
 
-        if (email.getDebugging()) {
+        if (email.getDebugging() != null && email.getDebugging()) {
             configureDebugLogs();
         }
     }
 
-    private String booleanAsString(final boolean state) {
+    private String booleanAsString(final Boolean state) {
+        if (state == null) {
+            return "false";
+        }
         return state ? "true" : "false";
     }
 

--- a/src/main/java/io/jacobking/quickticket/gui/controller/impl/SettingsController.java
+++ b/src/main/java/io/jacobking/quickticket/gui/controller/impl/SettingsController.java
@@ -64,7 +64,7 @@ public class SettingsController extends Controller {
                 Alerts.showWarning(
                         "File I/O",
                         "Enabling e-mail debugging has potential File I/O overhead.",
-                        "Do not keep this enabled for extended periods, only for testing. Log files will continously generate."
+                        "Do not keep this enabled for extended periods, only for testing. Log files will continuously generate.\n\nPlease note- debugging will not be enabled until the QuickTicket client has been restarted."
                 );
             }
         });


### PR DESCRIPTION
- debugging value was returning null, fixed to return false if null.
- updated warning to ensure the client needs to be restarted before e-mail debugging is enabled.